### PR TITLE
Add argument validation for inputQueueName

### DIFF
--- a/Rebus.AzureStorage/AzureStorage/Transport/AzureStorageQueuesTransport.cs
+++ b/Rebus.AzureStorage/AzureStorage/Transport/AzureStorageQueuesTransport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
@@ -30,6 +31,7 @@ namespace Rebus.AzureStorage.Transport
         readonly CloudQueueClient _queueClient;
         readonly string _inputQueueName;
         readonly ILog _log;
+        private readonly string _queueNameValidationRegex = "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$";
 
         /// <summary>
         /// Constructs the transport
@@ -44,6 +46,8 @@ namespace Rebus.AzureStorage.Transport
 
             if (inputQueueName != null)
             {
+                if (!Regex.IsMatch(inputQueueName, _queueNameValidationRegex))
+                    throw new ArgumentException("The inputQueueName must comprise only alphanumeric characters and hyphens, and must not have 2 consecutive hyphens.", nameof(inputQueueName));
                 _inputQueueName = inputQueueName.ToLowerInvariant();
             }
         }


### PR DESCRIPTION
Tiny change to add an axtra bit of argument validation to the inputQueueName.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
